### PR TITLE
logout on unauthorized response

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -12,6 +12,9 @@
           <div *ngIf="this.pwChanged" class="col-lg-6 info-container">
             <span>Your password has been changed!</span>
           </div>
+          <div *ngIf="this.tokenInvalidated" class="col-lg-6 info-container">
+            <span>You have been logged out!</span>
+          </div>
           <div *ngIf="this.notLoggedIn" class="col-lg-6 error-container">
             <span class="error-container-text">You are not logged in!</span>
           </div>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -15,6 +15,7 @@ export class LoginComponent implements OnInit {
   notLoggedIn: boolean;
   validated: boolean;
   pwChanged: boolean;
+  tokenInvalidated: boolean;
 
   constructor(
     private accountService: AccountService,
@@ -30,6 +31,7 @@ export class LoginComponent implements OnInit {
       this.notLoggedIn = params.notLoggedIn;
       this.validated = params.validated;
       this.pwChanged = params.pwChanged;
+      this.tokenInvalidated = params.tokenInvalidated;
     });
   }
 


### PR DESCRIPTION
Fixes #92 

This will simply return the user to the login page and display a message once he gets an unauthorized response regardless of context.

The drawback here is that if there is a minor bug and the user gets an unauthorized response, he/she can be logged out even if the token is still valid.

I suggest we use http 440 for this. both on the backend for notification and the frontend for case distinction.